### PR TITLE
Execute as and linker separately

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,10 @@
 /out
 /minigo
 /minigo.s
+/minigo.o
 /minigo2
 /minigo2.s
+/minigo2.o
 /minigo3
 /minigo3.s
 a.go
@@ -12,3 +14,8 @@ a.go
 /child
 /tmp/
 minigo.pos.s
+
+# Ignore generated file in README example
+/hello
+/hello.o
+/hello.s

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,8 @@ minigo.s: minigo
 
 # 2gen compiler
 minigo2: minigo.s
-	gcc -nostdlib -g -no-pie -o minigo2 minigo.s
+	as -o minigo.o minigo.s
+	gcc -nostdlib -g -no-pie -o minigo2  minigo.o
 
 # assembly for 3gen
 minigo2.s: minigo2
@@ -33,7 +34,8 @@ minigo2.s: minigo2
 
 # 3gen compiler
 minigo3: minigo2.s
-	gcc -nostdlib -g -no-pie -o minigo3 minigo2.s
+	as -o minigo2.o minigo2.s
+	gcc -nostdlib -g -no-pie -o minigo3 minigo2.o
 
 # assembly for 4gen
 minigo3.s: minigo3

--- a/README.md
+++ b/README.md
@@ -42,9 +42,10 @@ After entering the container, you can build and run it.
 
 ```sh
 $ make
-$ ./minigo t/hello/hello.go > a.s
-$ gcc -g -no-pie a.s
-$ ./a.out
+$ ./minigo t/hello/hello.go > hello.s
+$ as -o hello.o hello.s
+$ gcc -nostdlib -g -no-pie -o hello hello.o
+$ ./hello
 hello world
 ```
 
@@ -57,13 +58,15 @@ minigo 0.1.0
 Copyright (C) 2019 @DQNEO
 
 $ ./minigo *.go > /tmp/minigo2.s
-$ gcc -no-pie -o minigo2 /tmp/minigo2.s
+$ as -o /tmp/minigo2.o /tmp/minigo2.s
+$ gcc -nostdlib -no-pie -o minigo2 /tmp/minigo2.o
 $ ./minigo2 --version
 minigo 0.1.0
 Copyright (C) 2019 @DQNEO
 
 $ ./minigo2 *.go > /tmp/minigo3.s
-$ gcc -no-pie -o minigo3 /tmp/minigo3.s
+$ as -o /tmp/minigo3.o /tmp/minigo3.s
+$ gcc -nostdlib -no-pie -o minigo3 /tmp/minigo3.o
 $ ./minigo3 --version
 minigo 0.1.0
 Copyright (C) 2019 @DQNEO

--- a/testerror.sh
+++ b/testerror.sh
@@ -2,7 +2,7 @@
 
 ./minigo terror/panic/panic.go > /tmp/out/a.s
 
-gcc -nostdlib -g -no-pie /tmp/out/a.s && ./a.out >/dev/null
+as -o /tmp/out/a.o /tmp/out/a.s && gcc -nostdlib -g -no-pie /tmp/out/a.o && ./a.out >/dev/null
 
 if [[ $? -ne 1 ]]; then
     echo "FAILED"


### PR DESCRIPTION
I prefer a lower and more direct way of invoking compiler tools.
